### PR TITLE
スロットに設定されたアイテムの保存先を変更

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 2017,
+        "ecmaVersion": 2018,
         "sourceType": "module"
     },
     "rules": {

--- a/ItemSlot.js
+++ b/ItemSlot.js
@@ -676,7 +676,7 @@ window.$gameItemSlot = null;
                     if (numButton[i] != null) this.numButtoms[i] = SceneManager._scene.addChild(numButton[i]);
                 }
 
-                for ( let i = 0; i < this.slotCount; i++) {
+                for (let i = 0; i < this.slotCount; i++) {
                     numbers[i] = new PIXI.Text((i + 1), this.fontStyle);
                     numbers[i].x = Math.floor(this.buttonsX[i] + ((this.width  - numbers[i].width)  / 2));
                     numbers[i].y = Math.floor(this.buttonsY[i] + ((this.height - numbers[i].height) / 2));
@@ -714,7 +714,7 @@ window.$gameItemSlot = null;
         // 競合対策
         // スロットのデータ保存先を変えるマイグレーション処理
         if (typeof $gameParty._items.slots == 'object') {
-            $gameSystem._gameItemSlotData = {...$gameParty._items.slots };
+            $gameSystem._gameItemSlotData = { ...$gameParty._items.slots };
             delete $gameParty._items['slots'];
         }
 

--- a/ItemSlot.js
+++ b/ItemSlot.js
@@ -7,12 +7,14 @@
 /* global SceneManager   */
 /* global Scene_Item     */
 /* global $gameParty     */
+/* global $gameSystem    */
 /* global Graphics       */
 /* global Scene_Map      */
 /* global Sprite         */
 /* global TouchInput     */
 /* global Window_Base    */
 /* global Window_Message */
+/* global Game_System    */
 //=============================================================================
 // ItemSlot.js
 //=============================================================================
@@ -300,22 +302,22 @@ window.$gameItemSlot = null;
             if (!isItem(item)) return false;
 
             // プレイヤーの所有しているアイテムに選択されキーを設定する
-            if (typeof $gameParty._items.slots != 'object') return false;
-            if ($gameParty._items.slots[inputKey]) {
+            if (typeof $gameSystem._gameItemSlotData != 'object') return false;
+            if ($gameSystem._gameItemSlotData[inputKey]) {
                 // 対象スロットから取り消し
-                if ($gameParty._items.slots[inputKey].id == item.id) $gameParty._items.slots[inputKey] = null;
+                if ($gameSystem._gameItemSlotData[inputKey].id == item.id) $gameSystem._gameItemSlotData[inputKey] = null;
             } else {
                 // 既にスロットにセットされているアイテムの場合は処理を終了する
-                const keys = Object.keys($gameParty._items.slots);
+                const keys = Object.keys($gameSystem._gameItemSlotData);
                 for (let i = 0; i < keys.length; i++) {
-                    if ($gameParty._items.slots[keys[i]]) {
-                        const id = $gameParty._items.slots[keys[i]].id;
+                    if ($gameSystem._gameItemSlotData[keys[i]]) {
+                        const id = $gameSystem._gameItemSlotData[keys[i]].id;
                         if (item.id == id) return false;
                     }
                 }
 
                 // 対象スロットへセット
-                $gameParty._items.slots[inputKey] = item;
+                $gameSystem._gameItemSlotData[inputKey] = item;
             }
 
             SceneManager._scene._itemWindow.refresh();
@@ -418,10 +420,10 @@ window.$gameItemSlot = null;
             // パーティーが所有しているアイテムと個数の一覧
             const partyItems = $gameParty._items;
 
-            if(typeof $gameParty._items.slots != 'object') {
+            if (typeof $gameSystem._gameItemSlotData != 'object' || Object.keys($gameSystem._gameItemSlotData).length <= 0) {
                 // スロットの情報がない場合
-                $gameParty._items.slots = {};
-                for(let i = 0; i < this.slotCount; i++) $gameParty._items.slots[(i+1)] = null;
+                $gameSystem._gameItemSlotData = {};
+                for (let i = 0; i < this.slotCount; i++) $gameSystem._gameItemSlotData[(i+1)] = null;
 
                 // 描画
                 for (let i = 0; i < this.slotCount; i++) {
@@ -430,8 +432,7 @@ window.$gameItemSlot = null;
                 }
             } else {
                 // スロット情報がある場合
-                // パーティーが所有しているアイテム一覧からスロットに設定されたアイテム一覧を取り出す
-                let slotItems = $gameParty._items.slots;
+                let slotItems = $gameSystem._gameItemSlotData;
                 let keys = [];
                 keys = Object.keys(slotItems);
 
@@ -440,17 +441,17 @@ window.$gameItemSlot = null;
                     if (slotItems[keys[i]]) {
                         if (!$gameParty._items[slotItems[keys[i]].id]) {
                             // アイテムをすでに所有していない場合はスロットから外す
-                            $gameParty._items.slots[keys[i]] = null;
+                            $gameSystem._gameItemSlotData[keys[i]] = null;
                         }
                     }
                 }
 
                 // 更新
-                slotItems = $gameParty._items.slots;
+                slotItems = $gameSystem._gameItemSlotData;
                 keys = Object.keys(slotItems);
 
                 // スロットにアイテムを渡して描画
-                for (let i = 0; i < keys.length; i++) {
+                for (let i = 0; i < this.slotCount; i++) {
                     if (slotItems[keys[i]]) {
                         slotItems[keys[i]].haveCount = partyItems[slotItems[keys[i]].id]; // アイテムに所持数情報を追加・更新する
                         this.slots[(keys[i] - 1)].update(slotItems[keys[i]]);
@@ -541,7 +542,7 @@ window.$gameItemSlot = null;
                 slot.alpha = this.alpha;
 
                 // 選択状態生成
-                if(this.isClick) {
+                if (this.isClick) {
                     current = new PIXI.Graphics();
                     current.lineStyle(this.lineWeight, this.lineColor);
                     current.drawRoundedRect(
@@ -628,7 +629,7 @@ window.$gameItemSlot = null;
             this.buttonsX[0] = 10;
             this.buttonsY[0] = 10;
             this.colors[0]   = 0x000000;
-            for(let i = 1; i < this.slotCount; i++) {
+            for (let i = 1; i < this.slotCount; i++) {
                 this.numButtoms.push(null);
                 this.buttonsX[i] = this.buttonsX[(i - 1)] + Math.floor(this.width * 1.5);
                 this.buttonsY[i] = this.buttonsY[(i - 1)];
@@ -653,7 +654,7 @@ window.$gameItemSlot = null;
          * @return {undefined}
          */
         show() {
-            for(let i = 0; i < this.slotCount; i++) {
+            for (let i = 0; i < this.slotCount; i++) {
                 if(this.numbers[i]    != null) SceneManager._scene.removeChild(this.numbers[i]);
                 if(this.numButtoms[i] != null) SceneManager._scene.removeChild(this.numButtoms[i]);
             }
@@ -663,7 +664,7 @@ window.$gameItemSlot = null;
                 let numbers   = [];
                 let numButton = [];
 
-                for(let i = 0; i < this.slotCount; i++) {
+                for (let i = 0; i < this.slotCount; i++) {
                     // 枠生成
                     numButton[i] = new PIXI.Graphics();
                     numButton[i].lineStyle(0);
@@ -675,7 +676,7 @@ window.$gameItemSlot = null;
                     if (numButton[i] != null) this.numButtoms[i] = SceneManager._scene.addChild(numButton[i]);
                 }
 
-                for( let i = 0; i < this.slotCount; i++) {
+                for ( let i = 0; i < this.slotCount; i++) {
                     numbers[i] = new PIXI.Text((i + 1), this.fontStyle);
                     numbers[i].x = Math.floor(this.buttonsX[i] + ((this.width  - numbers[i].width)  / 2));
                     numbers[i].y = Math.floor(this.buttonsY[i] + ((this.height - numbers[i].height) / 2));
@@ -710,6 +711,14 @@ window.$gameItemSlot = null;
     let itemslot  = null;
     let setButton = null;
     PluginManager.registerCommand(pluginName, 'create', function() {
+        // 競合対策
+        // スロットのデータ保存先を変えるマイグレーション処理
+        if (typeof $gameParty._items.slots == 'object') {
+            $gameSystem._gameItemSlotData = {...$gameParty._items.slots };
+            delete $gameParty._items['slots'];
+        }
+
+        // スロット生成
         if (!itemslot) {
             itemslot = new ItemSlot(
                 slotCount
@@ -742,7 +751,7 @@ window.$gameItemSlot = null;
                 const slots = window.$gameItemSlot.slots;
                 let item  = null;
 
-                for(let i = 0; i < slots.length; i++) {
+                for (let i = 0; i < slots.length; i++) {
                     if (slots[i].isClick) item = slots[i].item;
                 }
 
@@ -752,28 +761,23 @@ window.$gameItemSlot = null;
                 return item[key];
             };
 
-            if(typeof $gameParty._items.slots == 'object') {
+            if (typeof $gameSystem._gameItemSlotData == 'object') {
                 // セーブデータ対策
                 // 過去のセーブデータよりスロット数を少ない仕様になった場合に既にセットされているアイテムを切り捨てる
-                const keys = Object.keys($gameParty._items.slots);
+                const keys = Object.keys($gameSystem._gameItemSlotData);
                 if (itemslot.slotCount < keys.length) {
                     const slots = {};
-                    for(let i = 0; i < slotCount; i++) {
-                        slots[(i+1)] = $gameParty._items.slots[(i+1)];
+                    for (let i = 0; i < slotCount; i++) {
+                        slots[(i+1)] = $gameSystem._gameItemSlotData[(i+1)];
                     }
 
                     // 入れ替え
-                    $gameParty._items.slots = slots;
+                    $gameSystem._gameItemSlotData = slots;
                 } else if (itemslot.slotCount > keys.length) {
                     // 多い場合は入れ物を追加しておく
-                    for(let i = keys.length; i < itemslot.slotCount; i++) $gameParty._items.slots[(i+1)] = null;
+                    for(let i = keys.length; i < itemslot.slotCount; i++) $gameSystem._gameItemSlotData[(i+1)] = null;
                 }
-
-                // 描画を更新
-                itemslot.update();
             }
-
-            itemSlotEnable = true;
         }
     });
 
@@ -804,6 +808,15 @@ window.$gameItemSlot = null;
     // -------------------------------------------
     // 以下はツクールMZにある機能を改造する処理群
     // -------------------------------------------
+    /**
+     * Game_Systemにスロットのデータの保存先を作成する
+     */
+    const _Game_System_initialize = Game_System.prototype.initialize;
+    Game_System.prototype.initialize = function(){
+        _Game_System_initialize.apply(this, arguments);
+        this._gameItemSlotData = {};
+    };
+
     /**
      * シーン更新時の挙動を改造する。
      * 入力判定系の処理を追加する。
@@ -842,7 +855,7 @@ window.$gameItemSlot = null;
             }
 
             // アイテムスロットを更新
-            if(itemSlotEnable) itemslot.update();
+            if (itemSlotEnable) itemslot.update();
         }
 
         // アイテム画面上の数字ボタンマウス左クリック
@@ -903,11 +916,11 @@ window.$gameItemSlot = null;
     const _Window_Base_prototype_drawItemName = Window_Base.prototype.drawItemName;
     Window_Base.prototype.drawItemName = function(item, x, y, width) {
         _Window_Base_prototype_drawItemName.apply(this, arguments);
-        if(!isItem(item)) return ;
+        if (!isItem(item)) return ;
 
-        const keys = Object.keys($gameParty._items.slots);
+        const keys = Object.keys($gameSystem._gameItemSlotData);
         for (let i = 0; i < keys.length; i++) {
-            if ($gameParty._items.slots[keys[i]] && $gameParty._items.slots[keys[i]].id == item.id) {
+            if ($gameSystem._gameItemSlotData[keys[i]] && $gameSystem._gameItemSlotData[keys[i]].id == item.id) {
                 this.contents.fontSize = itemSlotFontSize;
                 this.contents.drawText(keys[i], x, Math.floor(y + (this.contents.fontSize / 3)), width, 0, 'left');
                 this.resetFontSettings();
@@ -932,7 +945,7 @@ window.$gameItemSlot = null;
     const _Scene_Item_prototype_createItemWindow = Scene_Item.prototype.createItemWindow;
     Scene_Item.prototype.createItemWindow = function() {
         _Scene_Item_prototype_createItemWindow.apply(this, arguments);
-        if(!setButton) setButton = new SetButton(slotCount);
+        if (!setButton) setButton = new SetButton(slotCount);
         setButton.show();
     };
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RPGツクールMZ用のプラグイン。
 # プロジェクトへのインポート方法
 
 1. プラグインをダウンロードする。以下のリンクをクリックすると最新のバイナリを落とせる。
-    * [ItemSlot-1.0.4](https://github-storage.redspice.me/rpgmaker-mz/itemslot/ItemSlot-1.0.4.zip)
+    * [ItemSlot-1.1.0](https://github-storage.redspice.me/rpgmaker-mz/itemslot/ItemSlot-1.1.0.zip)
 
 3. ダウンロードしたZIPファイルを展開する。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -508,6 +508,11 @@
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
       "dev": true
     },
+    "caniuse-lite": {
+      "version": "1.0.30001292",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
+      "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw=="
+    },
     "chalk": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
@@ -577,28 +582,6 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-              "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.1"
-              }
-            }
-          }
-        }
       }
     },
     "class-utils": {
@@ -1619,6 +1602,27 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
     "glob-stream": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
@@ -1638,29 +1642,20 @@
       },
       "dependencies": {
         "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^4.0.1"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-              "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.1"
-              }
-            }
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           }
         },
         "is-glob": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -2031,7 +2026,8 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -2666,6 +2662,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
@@ -3947,25 +3949,17 @@
           "requires": {
             "ansi-regex": "^2.0.0"
           }
-        },
-        "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
-            }
-          }
         }
+      }
+    },
+    "yargs-parser": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
+      "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^3.0.0",
+        "object.assign": "^4.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "eslint": "^7.29.0",
     "gulp": "^4.0.2",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "caniuse-lite": "^1.0.30001292"
   }
 }


### PR DESCRIPTION
# 概要
## 以前
* アイテムスロットへ設定したアイテムを`$gameParty._items`に別途`slots`というキーを一つ生やして保存していた。
* 他プラグインによっては`$gameParty._items`の中身を再帰的に取得し処理を行っているものがある模様で競合を引き起こしていた。
## 修正内容
* アイテムスロットへ設定したアイテムは`$gameSystem`オブジェクト内に、`_gameItemSlotData`を生やしてそちらに保存するように修正

他プラグインとの競合に関しては優先して修正する内容ではないが、データの保存先自体は結果として適切ではないと判断して修正を入れている。

# 影響

この修正によってアイテムスロットへ設定したデータの保存先が変わるため破壊的な変更となる。内部でマイグレーション処理は入れているが、この変更を適用する前のセーブデータを読み込んだ場合は何かしらの影響が出る可能性がある。(適用前のセーブデータを読み込むことによる動作確認自体は実施済み。基本問題はないはず。)

# 備考

* 他軽微な修正内容を多数入れている。


